### PR TITLE
fix: linear_focused attention dimension mismatches in v_map_mlp and final_linear

### DIFF
--- a/hypercore/nn/attention/lorentz_former_conv.py
+++ b/hypercore/nn/attention/lorentz_former_conv.py
@@ -53,12 +53,17 @@ class LorentzMultiheadAttention(nn.Module):
         self.scale = nn.Parameter(torch.tensor([math.sqrt(num_heads * out_channels)]))
         self.bias = nn.Parameter(torch.zeros(()))
         if self.attention_type=='linear_focused':
-            self.v_map_mlp = nn.Linear(in_channels - 1, out_channels, bias=True)
+            _v_space = (out_channels - 2) if use_weight else (out_channels - 1)
+            self.v_map_mlp = nn.Linear(_v_space, _v_space, bias=True)
             self.norm_scale = nn.Parameter(torch.ones(()))
         self.power_k = power_k
         self.trans_heads_concat = trans_heads_concat
         if self.trans_heads_concat:
-            self.final_linear = nn.Linear(self.num_heads * (self.out_channels), self.num_heads * self.out_channels - 1) 
+            if self.attention_type == 'linear_focused':
+                _v_space = (out_channels - 2) if use_weight else (out_channels - 1)
+                self.final_linear = nn.Linear(self.num_heads * _v_space, self.num_heads * self.out_channels - 1) 
+            else:
+                self.final_linear = nn.Linear(self.num_heads * self.out_channels, self.num_heads * self.out_channels - 1) 
         self.normalize = normalize
 
     @staticmethod
@@ -175,7 +180,7 @@ class LorentzMultiheadAttention(nn.Module):
             attn_output = attn_output + vss  # preserve its rank, [B, N, H, D]
 
             if self.trans_heads_concat:
-                attn_output = self.final_linear(attn_output.reshape(attn_output.size(0), -1, self.num_heads * self.out_channels))
+                attn_output = self.final_linear(attn_output.reshape(attn_output.size(0), attn_output.size(1), -1))
             else:
                 attn_output = attn_output.mean(dim=1)
 


### PR DESCRIPTION
## Summary
Two dimension bugs in `LorentzMultiheadAttention` when `attention_type="linear_focused"`:

1.  `v_map_mlp` maps from `in_channels - 1` to `out_channels`, but in the linear-focused path it receives `v = hyp_vs[..., 1:]` whose last dimension is `out_channels - 2` (when `use_weight=True`). The result is added to `attn_output` which also has dimension `out_channels - 2`, so both the input and output of `v_map_mlp` must match that width.

2. When `trans_heads_concat=True`, `final_linear` input width is `num_heads * out_channels`, but the concatenated linear-focused output has width `num_heads * (out_channels - 2)`. The reshape in `linear_focus_attention` also hardcodes the wrong concat dimension.

Both bugs cause a `RuntimeError` on any valid input to the `linear_focused` path. The `full` attention path is unaffected.

## Scope
Code-only fix for the two dimension bugs I was running into. Does not change the linear-attention formulation itself.